### PR TITLE
fix: except nextjs conventions from no-default-export rule

### DIFF
--- a/src/eslint/configs/react.ts
+++ b/src/eslint/configs/react.ts
@@ -41,7 +41,7 @@ export async function react(): Promise<ConfigWithExtends[]> {
       },
       {
         files: [
-          "**/app/**/{page,loading,layout}.{js,jsx,ts,tsx}",
+          "**/app/**/{page,loading,layout,template,error,not-found,unauthorized,forbidden,default}.{js,jsx,ts,tsx}",
           "**/pages/**/*.{js,jsx,ts,tsx}",
         ],
         name: "solvro/next/pages",


### PR DESCRIPTION
The config does not allow for default exports in files that serve as boundaries or fallbacks in NextJS file-system conventions.

I think _not-found_, _error_, _template_ and _default_ filenames can be added.

_forbidden.js_ and _unauthorized.js_ are experimental in NextJS, but as long as they are maintained I don't see why they couldn't be added too.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates ESLint config to allow default exports for specific NextJS convention files in `react.ts`.
> 
>   - **ESLint Configuration**:
>     - Updates `react.ts` to allow default exports for NextJS convention files: `template`, `error`, `not-found`, `unauthorized`, `forbidden`, and `default`.
>     - Affects files in `**/app/**` and `**/pages/**` directories with extensions `.js`, `.jsx`, `.ts`, `.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Flib-web-solvro-config&utm_source=github&utm_medium=referral)<sup> for 57786d574d12657758c5f0ffa26d4727cb36607f. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->