### PR TITLE
fix: add test library exceptions to no-default-export

### DIFF
--- a/src/eslint/configs/imports.ts
+++ b/src/eslint/configs/imports.ts
@@ -54,6 +54,8 @@ export function imports(
           "next.config.*",
           "commitlint.config.*",
           ".releaserc.*",
+          "vitest.config.*",
+          "playwright.config.*",
         ],
         rules: {
           "import/no-default-export": "off",


### PR DESCRIPTION
można dodać też inne dla np cypress/jest, zależy jaki będzie trend dla libek testowych w Solvro

resolves #389 