### PR TITLE
fix(tests): ensure eslint v9

### DIFF
--- a/tests/utils/test-environment.ts
+++ b/tests/utils/test-environment.ts
@@ -267,12 +267,19 @@ export class TestEnvironment {
   }
 
   async createViteApp(appName: string, template = "react-ts"): Promise<string> {
-    return await this.create({
+    const appPath = await this.create({
       appName,
       creator: "vite@9",
       flags: ["--no-interactive", "--template", template],
       ensureInstall: true,
     });
+    await this.execute({
+      command: "installPackage",
+      args: ["eslint@9"],
+      label: "downgrade-eslint-version",
+      cwd: appPath,
+    });
+    return appPath;
   }
 
   async installSolvroConfig(appPath: string): Promise<void> {

--- a/tests/utils/test-environment.ts
+++ b/tests/utils/test-environment.ts
@@ -275,7 +275,7 @@ export class TestEnvironment {
     });
     await this.execute({
       command: "installPackage",
-      args: ["eslint@9"],
+      args: ["-D", "eslint@9", "@eslint/js@9"],
       label: "downgrade-eslint-version",
       cwd: appPath,
     });


### PR DESCRIPTION
instaluje ręcznie eslint v9 przy setupowaniu mockowych projektów żeby instalacja solvro configa się nie wywalała

tymczasowe rozwiązanie zanim dodane będzie wsparcie dla ESLint v10: #907 

resolves #900 